### PR TITLE
Fix for Xcode 10 build error

### DIFF
--- a/TPInAppReceipt/Source/InAppReceiptPayload.swift
+++ b/TPInAppReceipt/Source/InAppReceiptPayload.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct InAppReceiptPayload
+public struct InAppReceiptPayload
 {
     /// In-app purchase's receipts
     public let purchases: [InAppPurchase]


### PR DESCRIPTION
With Xcode 10 when building release app linking this framework there's an "Undefined symbols" error referencing this struct. Making this public this symbol gets exported and the error goes away. Tested for MacOS but iOS should have the same problem.